### PR TITLE
LaunchAllMumu.ahk adjustments

### DIFF
--- a/LaunchAllMumu.ahk
+++ b/LaunchAllMumu.ahk
@@ -42,8 +42,6 @@ Loop %Instances% {
     }
 }
 
-Run, "%A_ScriptDir%\PTCGPB.ahk"
-
 ExitApp
 
 
@@ -77,7 +75,8 @@ launchInstance(instanceNum := "")
     if(instanceNum != "") {
         mumuNum := getMumuInstanceNumFromPlayerName(instanceNum)
         if(mumuNum != "") {
-            Run, %mumuFolder%\shell\MuMuPlayer.exe -v %mumuNum%
+            ; Run, %mumuFolder%\shell\MuMuPlayer.exe -v %mumuNum%
+            Run_(mumuFolder . "\shell\MuMuPlayer.exe", "-v " . mumuNum)
         }
     }
 }
@@ -114,4 +113,57 @@ getMumuInstanceNumFromPlayerName(scriptName := "") {
 			}
 		}
 	}
+}
+
+; Function to run as a NON-adminstrator, since MuMu has issues if run as Administrator
+; See: https://www.reddit.com/r/AutoHotkey/comments/bfd6o1/how_to_run_without_administrator_privileges/
+/*
+  ShellRun by Lexikos
+    requires: AutoHotkey v1.1
+    license: http://creativecommons.org/publicdomain/zero/1.0/
+
+  Credit for explaining this method goes to BrandonLive:
+  http://brandonlive.com/2008/04/27/getting-the-shell-to-run-an-application-for-you-part-2-how/
+ 
+  Shell.ShellExecute(File [, Arguments, Directory, Operation, Show])
+  http://msdn.microsoft.com/en-us/library/windows/desktop/gg537745
+*/
+Run_(target, args:="", workdir:="") {
+    try
+        ShellRun(target, args, workdir)
+    catch e
+        Run % args="" ? target : target " " args, % workdir
+}
+ShellRun(prms*)
+{
+    shellWindows := ComObjCreate("Shell.Application").Windows
+    VarSetCapacity(_hwnd, 4, 0)
+    desktop := shellWindows.FindWindowSW(0, "", 8, ComObj(0x4003, &_hwnd), 1)
+   
+    ; Retrieve top-level browser object.
+    if ptlb := ComObjQuery(desktop
+        , "{4C96BE40-915C-11CF-99D3-00AA004AE837}"  ; SID_STopLevelBrowser
+        , "{000214E2-0000-0000-C000-000000000046}") ; IID_IShellBrowser
+    {
+        ; IShellBrowser.QueryActiveShellView -> IShellView
+        if DllCall(NumGet(NumGet(ptlb+0)+15*A_PtrSize), "ptr", ptlb, "ptr*", psv:=0) = 0
+        {
+            ; Define IID_IDispatch.
+            VarSetCapacity(IID_IDispatch, 16)
+            NumPut(0x46000000000000C0, NumPut(0x20400, IID_IDispatch, "int64"), "int64")
+           
+            ; IShellView.GetItemObject -> IDispatch (object which implements IShellFolderViewDual)
+            DllCall(NumGet(NumGet(psv+0)+15*A_PtrSize), "ptr", psv
+                , "uint", 0, "ptr", &IID_IDispatch, "ptr*", pdisp:=0)
+           
+            ; Get Shell object.
+            shell := ComObj(9,pdisp,1).Application
+           
+            ; IShellDispatch2.ShellExecute
+            shell.ShellExecute(prms*)
+           
+            ObjRelease(psv)
+        }
+        ObjRelease(ptlb)
+    }
 }

--- a/Monitor.ini
+++ b/Monitor.ini
@@ -4,6 +4,3 @@ instanceLaunchDelay=5000
 
 ; If launching all instances within the script itself, the amount of time to wait after to ensure they're loaded
 waitAfterBulkLaunch=20000
-
-; Auto launch the monitor script when running the main PTCGPB.ahk file (will wait ~10 minutes first)
-autoLaunchMonitor=1


### PR DESCRIPTION
Adjust LaunchAllMumu.ahk to not run the MuMu instances as Admin in case this script is run as Admin. Additionally, no longer run the PTCGPB.ahk after launching the MuMu instances so that we can instead run this script from the PTCGPB.ahk directly.